### PR TITLE
chore: update config with TTS and ASR tokens

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -58,10 +58,20 @@ export class ConfigFactory {
      */
     TTSAppId: 'Your TTS AppId',
     /**
+     * @brief 已开通需要的语音合成服务的token。
+     *        使用火山引擎双向流式语音合成服务时必填。  
+     */
+    TTSToken: undefined,
+    /**
      * @brief 必填, ASR(语音识别) AppId, 可于 https://console.volcengine.com/speech/app?s=g 中获取, 若无可先创建应用。
      * @note 创建应用时, 需要按需根据语言选择 "流式语音识别" 服务, 并选择对应的 App 进行绑定。
      */
     ASRAppId: 'Your ASR AppId',
+    /**
+     * @brief 已开通流式语音识别大模型服务 AppId 对应的 Access Token。
+     *        使用流式语音识别大模型服务时该参数为必填。  
+     */
+    ASRToken: undefined,
   };
 
   Model: AI_MODEL = Model[SCENE.INTELLIGENT_ASSISTANT];
@@ -142,6 +152,7 @@ export class ConfigFactory {
          */
         Mode: 'smallmodel',
         AppId: this.BaseConfig.ASRAppId,
+        ...(this.BaseConfig.ASRToken ? { AccessToken: this.BaseConfig.ASRToken } : {}),
         /**
          * @note 具体流式语音识别服务对应的 Cluster ID，可在流式语音服务控制台开通对应服务后查询。
          *       具体链接为: https://console.volcengine.com/speech/service/16?s=g
@@ -162,6 +173,7 @@ export class ConfigFactory {
       ProviderParams: {
         app: {
           AppId: this.BaseConfig.TTSAppId,
+          ...(this.BaseConfig.TTSToken ? { Token: this.BaseConfig.TTSToken } : {}),
           Cluster: TTS_CLUSTER.TTS,
         },
         audio: {


### PR DESCRIPTION
### ✨ 变更摘要  

- 在 `BaseConfig` 中新增 `TTSToken` 和 `ASRToken`。  
- 修复当用户使用 **火山引擎双向流式语音合成服务** 或 **流式语音识别大模型服务** 时，界面一直显示 "AI准备中，请稍后" 的问题。  

### 🔍 详细说明  

- **改动原因**：由于 `BaseConfig` 之前缺少 `TTSToken` 和 `ASRToken`，导致这些服务无法正常初始化，进而导致界面卡住的问题。  
- **变更内容**：  
  - 添加 `TTSToken` 和 `ASRToken` 相关配置项。  
  - 变更内容中的 **所有注释** 来源于 **官方文档**，确保准确性。  
  - **最小侵入式修改**，不影响任何现有业务逻辑。  

### ✅ 影响范围  

- **对现有功能无影响**。  
- **无 Breaking Changes**。  

### 🔬 测试验证  

- 本地测试通过，确认可正常工作。  
- 仅影响 `BaseConfig`，未改动其他核心逻辑。  